### PR TITLE
Updating model and deprecated tf parameter

### DIFF
--- a/align/detect_face.py
+++ b/align/detect_face.py
@@ -207,9 +207,9 @@ class Network(object):
     """
     @layer
     def softmax(self, target, axis, name=None):
-        max_axis = tf.reduce_max(target, axis, keep_dims=True)
+        max_axis = tf.reduce_max(target, axis, keepdims=True)
         target_exp = tf.exp(target-max_axis)
-        normalize = tf.reduce_sum(target_exp, axis, keep_dims=True)
+        normalize = tf.reduce_sum(target_exp, axis, keepdims=True)
         softmax = tf.div(target_exp, normalize, name)
         return softmax
     


### PR DESCRIPTION
Facenet released a new pre trained model (https://github.com/davidsandberg/facenet)
The keep_dims named parameter was deprecated, updated it with keepdims